### PR TITLE
add struct for floats in api json response

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -20,6 +20,14 @@ type Tick struct {
 	LastPrice               int64
 }
 
+type TickFloat struct {
+	PrimaryCurrency			string
+	SecondaryCurrency		string
+	CurrentHighestBidPrice	float64
+	CurrentLowestOfferPrice float64
+	LastPrice				float64
+}
+
 //OrderBook gets the current open orders
 type OrderBook struct {
 	PrimaryCurrency   string


### PR DESCRIPTION
The btcmarkets.net API returns floats for the `/market/*/*/tick` method:
`curl https://api.btcmarkets.net/market/BTC/AUD/tick`
`{"bestBid":24900.9,"bestAsk":25098.0,"lastPrice":25100.0,"currency":"AUD","instrument":"BTC","timestamp":1513701965,"volume24h":939.04711}`
